### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ which policies bind the member to those roles.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-policy-troubleshooter.svg
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policy-troubleshooter.svg
@@ -84,4 +84,4 @@ Next Steps
    APIs that we cover.
 
 .. _IAM Policy Troubleshooter Product documentation:  https://cloud.google.com/iam/docs/quickstart-client-libraries
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.