### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "policytroubleshooter",
     "name_pretty": "IAM Policy Troubleshooter API",
     "product_documentation": "https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/",
-    "client_documentation": "https://googleapis.dev/python/policytroubleshooter/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/policytroubleshooter/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ which policies bind the member to those roles.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policy-troubleshooter.svg
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
 .. _IAM Policy Troubleshooter: https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
-.. _Client Library Documentation: https://googleapis.dev/python/policytroubleshooter/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policytroubleshooter/latest
 .. _Product Documentation:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.