### PR TITLE
fix(deps): remove libcst dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
-    "libcst >= 0.2.5",
     "proto-plus >= 1.15.0",
     "grpc-google-iam-v1",
 ]

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -21,5 +21,4 @@
 # Then this file should have foo==1.14.0
 google-api-core==1.28.0
 grpc-google-iam-v1==0.12.3
-libcst==0.2.5
 proto-plus==1.15.0


### PR DESCRIPTION
`libcst` is only required to run the fixup scripts. This library was always generated using the microgenerator, so this dependency is not needed.

Also deletes library .tar.gz artifact from the root of the repository.