### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [1.4.1](https://github.com/googleapis/python-policy-troubleshooter/compare/v1.4.0...v1.4.1) (2022-03-05)
+## [1.4.1](https://github.com/googleapis/python-policy-troubleshooter/compare/v1.4.0...v1.4.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -25,7 +25,7 @@
 
 * add generated snippets ([#97](https://github.com/googleapis/python-policy-troubleshooter/issues/97)) ([2aa1400](https://github.com/googleapis/python-policy-troubleshooter/commit/2aa1400e34f2dcd032e78bb89420a0766e81a866))
 
-### [1.3.1](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.3.0...v1.3.1) (2021-11-01)
+## [1.3.1](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.3.0...v1.3.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -52,14 +52,14 @@
 
 * add context manager support in client ([#67](https://www.github.com/googleapis/python-policy-troubleshooter/issues/67)) ([b439623](https://www.github.com/googleapis/python-policy-troubleshooter/commit/b439623760bc9f84ce8472f38c3db32439f01bf9))
 
-### [1.1.3](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.2...v1.1.3) (2021-09-24)
+## [1.1.3](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.2...v1.1.3) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([56b6b0e](https://www.github.com/googleapis/python-policy-troubleshooter/commit/56b6b0e3b1637c6ea7ae5c6188d7556ddca25664))
 
-### [1.1.2](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.1...v1.1.2) (2021-07-29)
+## [1.1.2](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.1...v1.1.2) (2021-07-29)
 
 
 ### Bug Fixes
@@ -76,7 +76,7 @@
 
 * release as 1.1.2 ([#49](https://www.github.com/googleapis/python-policy-troubleshooter/issues/49)) ([0247df5](https://www.github.com/googleapis/python-policy-troubleshooter/commit/0247df51703c466a9bcd911696968b8d3533d6bf))
 
-### [1.1.1](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.0...v1.1.1) (2021-07-21)
+## [1.1.1](https://www.github.com/googleapis/python-policy-troubleshooter/compare/v1.1.0...v1.1.1) (2021-07-21)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.